### PR TITLE
Change credential ordering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(person("Thomas J.", "Leeper",
              person("Jonathan", "Stott", email = "jonathan.stott@magairports.com", role = c("cre", "aut")),
              person("Mike", "Kaminsky", email = "kaminsky.michael@gmail.com", role = "ctb"),
              person("Mark", "Douthwaite", email = "mark.douthwaite@peak.ai", role = "ctb"),
-             person("Jason", "Gofford", email = "jason.gofford@peak.ai", role = "ctb")
+             person("Jason", "Gofford", email = "jason.gofford@peak.ai", role = "ctb"),
+             person("Luke", "Dyer", email = "luke.dyer@peak.ai", role = "ctb")
             )
 Description: Generates version 2 and version 4 request signatures for Amazon Web Services ('AWS') <https://aws.amazon.com/> Application Programming Interfaces ('APIs') and provides a mechanism for retrieving credentials from environment variables, 'AWS' credentials files, and 'EC2' instance metadata. For use on 'EC2' instances, users will need to install the suggested package 'aws.ec2metadata' <https://cran.r-project.org/package=aws.ec2metadata>.
 License: GPL (>= 2)

--- a/R/assume_role.R
+++ b/R/assume_role.R
@@ -26,7 +26,7 @@ assume_role_with_web_identity <- function(
   
   token <- readChar(token_file, file.info(token_file)$size)
 
-  query <- list(
+  query_params <- list(
     Action="AssumeRoleWithWebIdentity",
     DurationSeconds=duration,
     RoleArn=role_arn,
@@ -34,13 +34,9 @@ assume_role_with_web_identity <- function(
     WebIdentityToken=token,
     Version=version
   )
-
-  ## ---- reverse engineered from httr ----
-  
-  ## construct URL
-  names  <- curl::curl_escape(names(query))
-  values <- lapply(query, curl::curl_escape)
-  query_str  <- paste0(names, "=", values, collapse = "&")
+  query_params_names  <- curl::curl_escape(names(query_params))
+  query_params_values <- lapply(query_params, curl::curl_escape)
+  query_str  <- paste0(query_params_names, "=", query_params_values, collapse = "&")
   query_url <- paste0(base_url, "/?", query_str)
   
   ## set up header

--- a/R/assume_role.R
+++ b/R/assume_role.R
@@ -21,7 +21,7 @@ assume_role_with_web_identity <- function(
   if (is.null(session_name)) {
     # strip resource ID from arn and use as default session name
     # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-    session_name <- gsub("/", "-", tail(strsplit(role_arn, ":")[[1]], 1))
+    session_name <- gsub("/", "-", utils::tail(strsplit(role_arn, ":")[[1]], 1))
   }
   
   token <- readChar(token_file, file.info(token_file)$size)

--- a/R/assume_role.R
+++ b/R/assume_role.R
@@ -47,7 +47,7 @@ assume_role_with_web_identity <- function(
   
   if (response$status_code == 200) {
     if (isTRUE(verbose)) {
-      message("Successfully fetched token.")
+      message("Successfully fetched token from web identiy provider.")
     }
     return(content)
   } else {

--- a/R/assume_role.R
+++ b/R/assume_role.R
@@ -38,12 +38,10 @@ assume_role_with_web_identity <- function(
   query_params_values <- lapply(query_params, curl::curl_escape)
   query_str  <- paste0(query_params_names, "=", query_params_values, collapse = "&")
   query_url <- paste0(base_url, "/?", query_str)
-  
-  ## set up header
-  handle <- curl::new_handle()
+
+  handle <- curl::new_handle()  # need to accept json headers
   curl::handle_setheaders(handle, "accept" = "application/json")
-  
-  ## get response & content
+
   response <- curl::curl_fetch_memory(query_url, handle = handle)
   content <- jsonlite::fromJSON(rawToChar(r$content))
   

--- a/R/assume_role.R
+++ b/R/assume_role.R
@@ -43,7 +43,7 @@ assume_role_with_web_identity <- function(
   curl::handle_setheaders(handle, "accept" = "application/json")
 
   response <- curl::curl_fetch_memory(query_url, handle = handle)
-  content <- jsonlite::fromJSON(rawToChar(r$content))
+  content <- jsonlite::fromJSON(rawToChar(response$content))
   
   if (response$status_code == 200) {
     if (isTRUE(verbose)) {

--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -293,8 +293,6 @@ check_for_env_vars <- function(region, file, default_region, session_token, verb
       message("Checking for credentials in Environment Variables")
     }
 
-
-
     # try to use environment variables if no user-supplied values
     # grab environment variables
     env <- list(key = Sys.getenv("AWS_ACCESS_KEY_ID"),

--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -12,7 +12,7 @@
 #' @details These functions locate values of AWS credentials (access key, secret access key, session token, and region) from likely sources. The order in which these are searched is as follows:
 #' \enumerate{
 #'   \item user-supplied values passed to the function
-#'   \item environment variables, first checking for Web Identity credentials (\env{AWS_ROLE_ARN} and \env{AWS_WEB_IDENTITY_TOKEN_FILE}), then default credentials (\env{AWS_ACCESS_KEY_ID}, \env{AWS_SECRET_ACCESS_KEY}, \env{AWS_DEFAULT_REGION}, and \env{AWS_SESSION_TOKEN})
+#'   \item environment variables, first checking for default credentials (\env{AWS_ACCESS_KEY_ID}, \env{AWS_SECRET_ACCESS_KEY}, \env{AWS_DEFAULT_REGION}, and \env{AWS_SESSION_TOKEN}); then for Web Identity Provider credentials (\env{AWS_ROLE_ARN} and \env{AWS_WEB_IDENTITY_TOKEN_FILE})
 #'   \item an instance role (on the running ECS task from which this function is called) as identified by \code{\link[aws.ec2metadata]{metadata}}, if the aws.ec2metadata package is installed
 #'   \item an IAM instance role (on the running EC2 instance from which this function is called) as identified by \code{\link[aws.ec2metadata]{metadata}}, if the aws.ec2metadata package is installed
 #'   \item a profile in a local credentials dot file in the current working directory, using the profile specified by \env{AWS_PROFILE}
@@ -292,22 +292,8 @@ check_for_env_vars <- function(region, file, default_region, session_token, verb
     if (isTRUE(verbose)) {
       message("Checking for credentials in Environment Variables")
     }
-  
-    identity <- list(arn=Sys.getenv("AWS_ROLE_ARN"),
-                     token_file=Sys.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
-    
-    if (!is_blank(identity$arn) && !is_blank(identity$token_file)){
-      response <- assume_role_with_web_identity(identity$arn, identity$token_file)
-      
-      creds <- response$AssumeRoleWithWebIdentityResponse$AssumeRoleWithWebIdentityResult$Credentials
-      key <- creds$AccessKeyId
-      secret <- creds$SecretAccessKey
-      session_token <- creds$SessionToken
 
-      region <- find_region_with_failsafe(region = region, default_region = default_region, verbose = verbose)
 
-      return(list(key = key, secret = secret, session_token = session_token, region = region))
-    }
 
     # try to use environment variables if no user-supplied values
     # grab environment variables
@@ -315,7 +301,9 @@ check_for_env_vars <- function(region, file, default_region, session_token, verb
                 secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
                 profile = Sys.getenv("AWS_PROFILE"),
                 session_token = Sys.getenv("AWS_SESSION_TOKEN"),
-                region = Sys.getenv("AWS_DEFAULT_REGION"))
+                region = Sys.getenv("AWS_DEFAULT_REGION"),
+                arn=Sys.getenv("AWS_ROLE_ARN"),
+                token_file=Sys.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
 
     if (!is_blank(env$session_token)) {
         session_token <- env$session_token
@@ -344,6 +332,22 @@ check_for_env_vars <- function(region, file, default_region, session_token, verb
         
         # early return
         return(list(key = key, secret = secret, session_token = session_token, region = region))
+
+    } else if (!is_blank(env$arn) && !is_blank(env$token_file)){  # Web Identity Provider
+        if (isTRUE(verbose)) {
+            message("Using Environment Variables 'AWS_WEB_IDENTITY_TOKEN_FILE' and `AWS_ROLE_ARN`")
+            message("to assume role with Web Identity Provider")
+        }
+      response <- assume_role_with_web_identity(env$arn, env$token_file)
+
+      creds <- response$AssumeRoleWithWebIdentityResponse$AssumeRoleWithWebIdentityResult$Credentials
+      key <- creds$AccessKeyId
+      secret <- creds$SecretAccessKey
+      session_token <- creds$SessionToken
+
+      region <- find_region_with_failsafe(region = region, default_region = default_region, verbose = verbose)
+
+      return(list(key = key, secret = secret, session_token = session_token, region = region))
     } else if (!is_blank(env$profile)) {
         return(check_credentials_file(env$profile, file, region, default_region, verbose))
     }

--- a/man/locate_credentials.Rd
+++ b/man/locate_credentials.Rd
@@ -39,7 +39,7 @@ Locate AWS credentials from likely sources
 These functions locate values of AWS credentials (access key, secret access key, session token, and region) from likely sources. The order in which these are searched is as follows:
 \enumerate{
   \item user-supplied values passed to the function
-  \item environment variables, first checking for Web Identity credentials (\env{AWS_ROLE_ARN} and \env{AWS_WEB_IDENTITY_TOKEN_FILE}), then default credentials (\env{AWS_ACCESS_KEY_ID}, \env{AWS_SECRET_ACCESS_KEY}, \env{AWS_DEFAULT_REGION}, and \env{AWS_SESSION_TOKEN})
+  \item environment variables, first checking for default credentials (\env{AWS_ACCESS_KEY_ID}, \env{AWS_SECRET_ACCESS_KEY}, \env{AWS_DEFAULT_REGION}, and \env{AWS_SESSION_TOKEN}); then for Web Identity Provider credentials (\env{AWS_ROLE_ARN} and \env{AWS_WEB_IDENTITY_TOKEN_FILE})
   \item an instance role (on the running ECS task from which this function is called) as identified by \code{\link[aws.ec2metadata]{metadata}}, if the aws.ec2metadata package is installed
   \item an IAM instance role (on the running EC2 instance from which this function is called) as identified by \code{\link[aws.ec2metadata]{metadata}}, if the aws.ec2metadata package is installed
   \item a profile in a local credentials dot file in the current working directory, using the profile specified by \env{AWS_PROFILE}


### PR DESCRIPTION
Addresses the [PR comment](https://github.com/cloudyr/aws.signature/pull/63/files#r727952704) to change the ordering of the credentials to better match [boto3's choices](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).

In addition: 
- some small refactoring
- code comment cleanups
- added debugging/verbose message if credentials are found using Web Identity Provider

## Testing

See result on `newtest` tenant: https://platform.test.peak.ai/factory/workflows/details/test-aws-s3-access/9175
